### PR TITLE
Inline diagnostics font color fix

### DIFF
--- a/Darcula Theme/Darcula Theme.vstheme
+++ b/Darcula Theme/Darcula Theme.vstheme
@@ -8047,15 +8047,15 @@
       </Color>
       <Color Name="inline diagnostics - syntax error">
         <Background Type="CT_RAW" Source="FFFC3E36" />
-        <Foreground Type="CT_RAW" Source="FF000000" />
+        <Foreground Type="CT_RAW" Source="FFB7B8B9" />
       </Color>
       <Color Name="inline diagnostics - compiler warning">
         <Background Type="CT_RAW" Source="FF95BD7D" />
-        <Foreground Type="CT_RAW" Source="FF000000" />
+        <Foreground Type="CT_RAW" Source="FFB7B8B9" />
       </Color>
       <Color Name="inline diagnostics - Edit and Continue">
         <Background Type="CT_RAW" Source="FF800080" />
-        <Foreground Type="CT_RAW" Source="FF000000" />
+        <Foreground Type="CT_RAW" Source="FFB7B8B9" />
       </Color>
       <Color Name="Track additions in documents under source control">
         <Background Type="CT_RAW" Source="FF107C10" />


### PR DESCRIPTION
Inline diagnostics font color fix. Previous (black) color is barely visible on a dark background. BTW - great theme!
![fix](https://github.com/FINNSEEFLY/Darcula-Theme-VS-2022/assets/62500135/c76b27af-4cd5-4406-a21d-2e41ca79f2c5)
